### PR TITLE
Adding PHP Examples

### DIFF
--- a/ServiceSamples/PHPConsoleApplication/AXAccessHelper.php
+++ b/ServiceSamples/PHPConsoleApplication/AXAccessHelper.php
@@ -1,0 +1,62 @@
+﻿<?php
+	//Require other files.
+	require_once 'Settings.php';
+	
+	class AXAccessHelper
+	{
+		// Add required headers like authorization header, service version etc.
+		public static function AddRequiredHeadersAndSettings($ch, $postData = '')
+		{
+			//Generate the authentication header
+			$authHeader = self::getAuthenticationHeader(Settings::$appTenantDomainName);
+			// Add authorization header, request/response format header( for json) and a header to request content for Update and delete operations.  
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array($authHeader,  'Accept:application/json;odata=minimalmetadata',
+														'Content-Type:application/json;odata=minimalmetadata', 'Prefer:return-content',
+														'Content-Length: ' . strlen($postData)));
+            if ($postData != '') {
+				curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+			}
+			// Set the option to recieve the response back as string.
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+			// By default https does not work for CURL.
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		}
+		
+		public static function getAuthenticationHeader($appTenantDomainName){
+			//resource
+			$appResource = urlencode(settings::$appADResource);
+			//clientID
+			$appClientID = urlencode(settings::$appADClientId);
+			//username
+			$appUserID = urlencode(settings::$appUserID);
+			// Password
+			$appUserPassword = urlencode(settings::$password);
+			
+			// Construct the body for the STS request
+			$authenticationRequestBody = 'resource='.$appResource.'&client_id='.$appClientID.'&grant_type=password&username='.$appUserID.'&password='.$appUserPassword.'&scope=openid';
+			
+			//Using curl to post the information to STS and get back the authentication response    
+			$ch = curl_init();
+			// set url 
+			$stsUrl = 'https://login.windows.net/'.$appTenantDomainName.'/oauth2/token?api-version=1.0';        
+			curl_setopt($ch, CURLOPT_URL, $stsUrl); 
+			// Get the response back as a string 
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+			// Mark as Post request
+			curl_setopt($ch, CURLOPT_POST, 1);
+			// Set the parameters for the request
+			curl_setopt($ch, CURLOPT_POSTFIELDS,  $authenticationRequestBody);
+			
+			// By default, HTTPS does not work with curl.
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			// read the output from the post request
+			$output = curl_exec($ch);         
+			// close curl resource to free up system resources
+			curl_close($ch);      
+			// decode the response from sts using json decoder
+			$tokenOutput = json_decode($output);
+			return 'Authorization:' . $tokenOutput->{'token_type'}.' '.$tokenOutput->{'access_token'};
+			//return $tokenOutput->{'token_type'}.' '.$tokenOutput->{'access_token'};
+		}
+	}
+?>

--- a/ServiceSamples/PHPConsoleApplication/App.config
+++ b/ServiceSamples/PHPConsoleApplication/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/ServiceSamples/PHPConsoleApplication/PHPConsoleApplication.csproj
+++ b/ServiceSamples/PHPConsoleApplication/PHPConsoleApplication.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{154E69A6-FD19-4280-A621-B1457B6FE30C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PHPConsoleApplication</RootNamespace>
+    <AssemblyName>PHPConsoleApplication</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="AXAccessHelper.php">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="PHPExamples.php">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Program.php">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Settings.php">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ServiceSamples/PHPConsoleApplication/PHPExamples.php
+++ b/ServiceSamples/PHPConsoleApplication/PHPExamples.php
@@ -1,0 +1,93 @@
+﻿<?php
+	//Require other files.
+	require_once 'AXAccessHelper.php';
+	
+	class PHPExamples
+	{
+		// Constructs a Http GET request to a feed passed in as paremeter.
+		// Returns the json decoded respone as the objects that were recieved in feed.
+		public static function getProducts(){
+			// initiaze curl which is used to make the http request.
+			$ch = curl_init();
+			// Add authorization and other headers. Also set some common settings.
+			AXAccessHelper::AddRequiredHeadersAndSettings($ch);
+			// set url 
+			$odataURL = Settings::$appADResource.'/data/ReleasedDistinctProducts?$filter=dataAreaId%20eq%20\'USMF\'&cross-company=true'; 
+			curl_setopt($ch, CURLOPT_URL, $odataURL);
+			//Enable fiddler to capture request
+			//curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+			// $output contains the output string
+			$output = curl_exec($ch);
+			// close curl resource to free up system resources 
+			curl_close($ch);      
+			$jsonOutput = json_decode($output);
+			// There is a field for odata metadata that we ignore and just consume the value
+			return $jsonOutput->{'value'};
+		}
+		
+		public static function getInventory(){
+			// initiaze curl which is used to make the http request.
+			$ch = curl_init();
+			// Add authorization and other headers. Also set some common settings.
+			AXAccessHelper::AddRequiredHeadersAndSettings($ch);
+			// set url 
+			$odataURL = Settings::$appADResource.'/data/InventorySitesOnHand?$filter=dataAreaId%20eq%20\'USMF\'%20and%20InventorySiteId%20eq%20\'2\'&cross-company=true'; 
+			curl_setopt($ch, CURLOPT_URL, $odataURL);
+			//Enable fiddler to capture request
+			//curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+			// $output contains the output string
+			$output = curl_exec($ch);
+			// close curl resource to free up system resources 
+			curl_close($ch);      
+			$jsonOutput = json_decode($output);
+			// There is a field for odata metadata that we ignore and just consume the value
+			return $jsonOutput->{'value'};
+		}
+		
+		public static function getUserSessionInfo(){
+			// initiaze curl which is used to make the http request.
+			$ch = curl_init();
+			// Add authorization and other headers. Also set some common settings.
+			AXAccessHelper::AddRequiredHeadersAndSettings($ch);
+			// set url 
+			$odataURL = Settings::$appADResource.'/api/services/UserSessionService/AifUserSessionService/GetUserSessionInfo'; 
+			curl_setopt($ch, CURLOPT_URL, $odataURL);
+			//Enable fiddler to capture request
+			//curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");                                                                     
+			// $output contains the output string
+			$output = curl_exec($ch);
+			// close curl resource to free up system resources 
+			curl_close($ch);      
+			$jsonOutput = json_decode($output);
+			return $jsonOutput;
+		}
+		
+		public static function setTimeZone(){
+			date_default_timezone_set('UTC');
+			// initiaze curl which is used to make the http request.
+			$ch = curl_init();
+			
+			$applyTimeZoneContract = array(
+				'dateTime'	 => date(DATE_RFC2822),
+				'timeZoneOffset' => 3
+			);
+			
+			$postData = json_encode($applyTimeZoneContract);
+			// Add authorization and other headers. Also set some common settings.
+			AXAccessHelper::AddRequiredHeadersAndSettings($ch, $postData);
+			// set url 
+			$odataURL = Settings::$appADResource.'/api/services/UserSessionService/AifUserSessionService/ApplyTimeZone'; 
+			curl_setopt($ch, CURLOPT_URL, $odataURL);
+			//Enable fiddler to capture request
+			//curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");                                                                     
+			// $output contains the output string
+			$output = curl_exec($ch);
+			// close curl resource to free up system resources 
+			curl_close($ch);      
+			$jsonOutput = json_decode($output);
+			return $jsonOutput;
+		}	
+	}
+?>

--- a/ServiceSamples/PHPConsoleApplication/Program.cs
+++ b/ServiceSamples/PHPConsoleApplication/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PHPConsoleApplication
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string command = @"PHP.exe";
+            string phpArgs = "Program.php";
+
+            try
+            {
+                Process process = new Process();
+                process.StartInfo.FileName = command;
+                process.StartInfo.Arguments = phpArgs;
+                process.Start();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+            }
+        }
+    }
+}

--- a/ServiceSamples/PHPConsoleApplication/Program.php
+++ b/ServiceSamples/PHPConsoleApplication/Program.php
@@ -1,0 +1,24 @@
+﻿<?php 
+	require_once 'Settings.php';
+	require_once 'PHPExamples.php';  
+	
+	echo 'Calling OData service endpoint:'.PHP_EOL;
+	$products = PHPExamples::getProducts(); 
+	
+	foreach ($products as $product){
+		echo($product->ProductNumber.' - '.$product->ProductSearchName.PHP_EOL);
+	}
+	
+	echo PHP_EOL.'Calling OData inventory endpoint:'.PHP_EOL;
+	$inventoryData = PHPExamples::getInventory(); 
+	
+	foreach ($inventoryData as $inv){
+		echo($inv->ProductName.' - '.$inv->AvailableOnHandQuantity.PHP_EOL);
+	}
+	
+	echo PHP_EOL.'Calling JSON service with no parameters:'.PHP_EOL;
+	echo var_dump(PHPExamples::getUserSessionInfo());
+	
+	echo PHP_EOL.'Calling JSON service with data contract parameter:'.PHP_EOL;
+	echo var_dump(PHPExamples::setTimeZone());
+?>

--- a/ServiceSamples/PHPConsoleApplication/Properties/AssemblyInfo.cs
+++ b/ServiceSamples/PHPConsoleApplication/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PHPConsoleApplication")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PHPConsoleApplication")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("154e69a6-fd19-4280-a621-b1457b6fe30c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ServiceSamples/PHPConsoleApplication/Settings.php
+++ b/ServiceSamples/PHPConsoleApplication/Settings.php
@@ -1,0 +1,11 @@
+﻿<?php
+	class Settings
+	{        
+		public static $appADResource = '';
+		public static $appTenantDomainName = '';
+		public static $appADClientId = '';
+		
+		public static $appUserID = '';    
+		public static $password = '';
+	}
+?>

--- a/ServiceSamples/ServiceSamples.sln
+++ b/ServiceSamples/ServiceSamples.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ODataUtility", "ODataUtilit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonConsoleApplication", "JsonConsoleApplication\JsonConsoleApplication.csproj", "{003F5F9E-658D-4C90-B185-6726A5CF41FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PHPConsoleApplication", "PHPConsoleApplication\PHPConsoleApplication.csproj", "{154E69A6-FD19-4280-A621-B1457B6FE30C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{003F5F9E-658D-4C90-B185-6726A5CF41FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{003F5F9E-658D-4C90-B185-6726A5CF41FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{003F5F9E-658D-4C90-B185-6726A5CF41FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{154E69A6-FD19-4280-A621-B1457B6FE30C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{154E69A6-FD19-4280-A621-B1457B6FE30C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{154E69A6-FD19-4280-A621-B1457B6FE30C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{154E69A6-FD19-4280-A621-B1457B6FE30C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +72,6 @@ Global
 		{71CAD5F3-B055-4BDC-A77F-5B5009E9D7C3} = {D09E6460-3148-4A92-8D6A-2C478E119F0E}
 		{74D74B3E-9B32-4E5D-9639-80988F58696C} = {8B249783-ED3B-4990-BF1E-7C163B3670E0}
 		{003F5F9E-658D-4C90-B185-6726A5CF41FC} = {D09E6460-3148-4A92-8D6A-2C478E119F0E}
+		{154E69A6-FD19-4280-A621-B1457B6FE30C} = {D09E6460-3148-4A92-8D6A-2C478E119F0E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Added a set of PHP examples for invoking OData endpoints - with OAuth code largely provided from this repo: https://github.com/Azure-Samples/active-directory-php-graphapi-web/tree/master/PHP.

The C# Console Application is just a wrapper around invoking the PHP command line interpreter.  I could also show the examples as a simple PHP web page - which is likely how most people will utilize these samples - but the actual PHP code doesn't need to change for this.