### PR TITLE
Set TLS version to 1.2 before making SOAP calls

### DIFF
--- a/ServiceSamples/JsonConsoleApplication/Program.cs
+++ b/ServiceSamples/JsonConsoleApplication/Program.cs
@@ -11,6 +11,15 @@ namespace OAuthXppConsoleApplication
 
         static void Main(string[] args)
         {
+            /* Helpful Note: 
+             * If you are targetting SOAP endpoints on Sandbox or Prod AX environemnts you MUST make sure to use TLS 1.2
+             * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
+             * Note that this statement may not work in .NET 4.0, 3.0 or below.
+             * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.
+             */
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var request = HttpWebRequest.Create(GetUserSessionOperationPath);
             request.Headers[OAuthHelper.OAuthHeader] = OAuthHelper.GetAuthenticationHeader();
             request.Method = "POST";

--- a/ServiceSamples/JsonConsoleApplication/Program.cs
+++ b/ServiceSamples/JsonConsoleApplication/Program.cs
@@ -11,8 +11,7 @@ namespace OAuthXppConsoleApplication
 
         static void Main(string[] args)
         {
-            /* Helpful Note: 
-             * If you are targetting SOAP endpoints on Sandbox or Prod AX environemnts you MUST make sure to use TLS 1.2
+            /* When making service requets to Sandbox or Prod AX environemnts it must be ensured that TLS version is 1.2
              * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
              * Note that this statement may not work in .NET 4.0, 3.0 or below.
              * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.

--- a/ServiceSamples/ODataConsoleApplication/Program.cs
+++ b/ServiceSamples/ODataConsoleApplication/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.OData.Client;
 using ODataUtility.Microsoft.Dynamics.DataEntities;
 using System;
 using System.Linq;
+using System.Net;
 
 namespace ODataConsoleApplication
 {
@@ -12,6 +13,14 @@ namespace ODataConsoleApplication
 
         static void Main(string[] args)
         {
+            /* When making service requets to Sandbox or Prod AX environemnts it must be ensured that TLS version is 1.2
+             * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
+             * Note that this statement may not work in .NET 4.0, 3.0 or below.
+             * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.
+             */
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // To test custom entities, regenerate "ODataClient.tt" file.
             // https://blogs.msdn.microsoft.com/odatateam/2014/03/11/tutorial-sample-how-to-use-odata-client-code-generator-to-generate-client-side-proxy-class/
 

--- a/ServiceSamples/PHPConsoleApplication/Program.cs
+++ b/ServiceSamples/PHPConsoleApplication/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,6 +12,14 @@ namespace PHPConsoleApplication
     {
         static void Main(string[] args)
         {
+            /* When making service requets to Sandbox or Prod AX environemnts it must be ensured that TLS version is 1.2
+             * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
+             * Note that this statement may not work in .NET 4.0, 3.0 or below.
+             * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.
+             */
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             string command = @"PHP.exe";
             string phpArgs = "Program.php";
 

--- a/ServiceSamples/SoapConsoleApplication/Program.cs
+++ b/ServiceSamples/SoapConsoleApplication/Program.cs
@@ -1,6 +1,7 @@
 ﻿using AuthenticationUtility;
 using SoapUtility.UserSessionServiceReference;
 using System;
+using System.Net;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 
@@ -13,6 +14,15 @@ namespace SoapConsoleApplication
         [STAThread]
         static void Main(string[] args)
         {
+            /* Helpful Note: 
+             * If you are targetting SOAP endpoints on Sandbox or Prod AX environemnts you MUST make sure to use TLS 1.2
+             * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
+             * Note that this statement may not work in .NET 4.0, 3.0 or below.
+             * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.
+             */
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var aosUriString = ClientConfiguration.Default.UriString;
 
             var oauthHeader = OAuthHelper.GetAuthenticationHeader();

--- a/ServiceSamples/SoapConsoleApplication/Program.cs
+++ b/ServiceSamples/SoapConsoleApplication/Program.cs
@@ -14,8 +14,7 @@ namespace SoapConsoleApplication
         [STAThread]
         static void Main(string[] args)
         {
-            /* Helpful Note: 
-             * If you are targetting SOAP endpoints on Sandbox or Prod AX environemnts you MUST make sure to use TLS 1.2
+            /* When making service requets to Sandbox or Prod AX environemnts it must be ensured that TLS version is 1.2
              * .NET 4.5 supports TLS 1.2 but it is not the default protocol. The below statement can set TLS version explicity.
              * Note that this statement may not work in .NET 4.0, 3.0 or below.
              * Also note that in .NET 4.6 and above TLS 1.2 is the default protocol.


### PR DESCRIPTION
Sandbox and PROD environments only accept TLS 1.2
So we are explicitly setting TLS version to 1.2 before making SOAP calls. 