### PR TITLE
Clarified how to use AAD web app authentication.

### DIFF
--- a/ServiceSamples/JsonConsoleApplication/Program.cs
+++ b/ServiceSamples/JsonConsoleApplication/Program.cs
@@ -8,6 +8,7 @@ using System.Web;
 using System.Security.Authentication;
 using System.Text;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace OAuthXppConsoleApplication
 {
@@ -16,13 +17,20 @@ namespace OAuthXppConsoleApplication
         // In the AOT you will find UserSessionService in Service Groups and AifUserSessionService under Services.
         public static string sessionUrl = "/api/services/UserSessionService/AifUserSessionService/GetUserSessionInfo";
         
+        // Set to true to authenticate as an AAD Web App, or false to autenticate as a Native AAD App.
+        // See https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-app-types
+        private const bool UseAadWebAppAuthentication = false;
+
         static void Main(string[] args)
         {
-            string GetUserSessionOperationPath = string.Format("{0}{1}", ClientConfiguration.Default.UriString.TrimEnd('/'), sessionUrl);
+            var uriPrefix = UseAadWebAppAuthentication
+                ? ClientConfiguration.Default.ActiveDirectoryResource
+                : ClientConfiguration.Default.UriString;
+            string GetUserSessionOperationPath = string.Format("{0}{1}", uriPrefix.TrimEnd('/'), sessionUrl);
             
             var request = HttpWebRequest.Create(GetUserSessionOperationPath);     
             // If you call GetAuthenticationHeader with true you will the auth via AAD Web App, otherwise via Native AAD App
-            request.Headers[OAuthHelper.OAuthHeader] = OAuthHelper.GetAuthenticationHeader();
+            request.Headers[OAuthHelper.OAuthHeader] = OAuthHelper.GetAuthenticationHeader(UseAadWebAppAuthentication);
             request.Method = "POST";
             request.ContentLength = 0;
 


### PR DESCRIPTION
The sample was using _ClientConfiguration.Default.UriString_ for the operation path, which was causing an error when calling _OAuthHelper.GetAuthenticationHeader(true)_. This patch adds a boolean constant, _UseAadWebAppAuthentication_, and uses its value to set the correct operation path for the chosen authentication.

The documentation for _UriString_ says "You only need to populate this section if you are logging on via a native app. For Service to Service scenarios in which you e.g. use a service principal you don't need that." I left it unchanged. Then even though I passed true to _OAuthHelper.GetAuthenticationHeader_ and got a valid token, my request to the actual session operation path would just time out.

I spent many hours looking for other solutions and starting to write my own implementation from scratch before I found the problem. This pull request will hopefully save some other developers the effort!